### PR TITLE
exceptionHandlingPracticalTask

### DIFF
--- a/exceptionPracticalTask.js
+++ b/exceptionPracticalTask.js
@@ -1,0 +1,17 @@
+
+
+
+try {
+    console.log(a);
+    let a = 3;
+} catch (err) {
+    console.log('let must be declare');
+};
+
+
+try {
+    1 / 0
+    if (1 / 0 === indefinat) throw Error()
+} catch (error) {
+    console.log('cannot be divided by zero');
+};


### PR DESCRIPTION
In a try catch construction, wrap the code: console.log (a), let a = 3. And display an error - ‘let must be declared’ before use. 
When running 1/0, the error 'cannot be divided by zero'

Screenshot: 
![exceptionPracicalTask](https://github.com/VitaliMart/exception_handling/assets/107574295/32dacfb2-cc27-4dd6-9e54-587472c90959)
